### PR TITLE
Waits for autosize before calculating canvas

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -178,14 +178,12 @@ function cancelChanges() {
 // Crop
 function showCrop() {
   switchEditorMode(EDITOR_MODE.CROP);
-  Fliplet.Widget.autosize();
-  // Wait for autosize to do it's job
-  // Prevents bad calculation of the canvas
-  setTimeout(function() {
-    canvasEditor.applyEditorCanvasChanges();
-    canvasEditor.createCropMask(updateCropCoords);
-    showCustomCropRatio();
-  }, 100);
+  Fliplet.Widget.autosize()
+    .then(function () {
+      canvasEditor.applyEditorCanvasChanges();
+      canvasEditor.createCropMask(updateCropCoords);
+      showCustomCropRatio();
+    });
 }
 
 function showCustomCropRatio() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -178,10 +178,14 @@ function cancelChanges() {
 // Crop
 function showCrop() {
   switchEditorMode(EDITOR_MODE.CROP);
-  canvasEditor.applyEditorCanvasChanges();
-  canvasEditor.createCropMask(updateCropCoords);
-  showCustomCropRatio();
   Fliplet.Widget.autosize();
+  // Wait for autosize to do it's job
+  // Prevents bad calculation of the canvas
+  setTimeout(function() {
+    canvasEditor.applyEditorCanvasChanges();
+    canvasEditor.createCropMask(updateCropCoords);
+    showCustomCropRatio();
+  }, 100);
 }
 
 function showCustomCropRatio() {


### PR DESCRIPTION
- Before, the calculations where wrong, because when the calculations
kicked in, the DOM had a scroll bar because autosize didn’t run in time
- Fixes https://github.com/Fliplet/fliplet-studio/issues/908