### PR TITLE
Crop is working now in the gallery component

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -178,12 +178,10 @@ function cancelChanges() {
 // Crop
 function showCrop() {
   switchEditorMode(EDITOR_MODE.CROP);
-  Fliplet.Widget.autosize()
-    .then(function () {
-      canvasEditor.applyEditorCanvasChanges();
-      canvasEditor.createCropMask(updateCropCoords);
-      showCustomCropRatio();
-    });
+  canvasEditor.applyEditorCanvasChanges();
+  canvasEditor.createCropMask(updateCropCoords);
+  showCustomCropRatio();
+
 }
 
 function showCustomCropRatio() {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/3119

## Description
Removed Fliplet.Widget.autosize from showCrop function.

## Screenshots/screencasts
![GalleryCrop](https://user-images.githubusercontent.com/53430352/63756752-9248d200-c8c1-11e9-8fa7-9a14d928aab3.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
Fliplet.Widget.autosize was removed because it wasn't called in the gallery component. I checked this in the image component as well and haven't found any visual changes.