### PR TITLE
The "Cancel" button is now aligned with "Crop", "Resize" and "Apply rotation" buttons 

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -154,3 +154,7 @@ html.provider-inline .image-widget-holder {
   max-width: 100%;
   vertical-align: middle;
 }
+
+.margin-top-0 {
+  margin-top: 0 !important;
+}

--- a/interface.html
+++ b/interface.html
@@ -17,7 +17,7 @@
       </div>
       <p id="image-editor-changes">
         <button class="btn btn-primary" id="saveImageChanges"><i class="fa fa-check"></i> Save changes</button>
-        <button class="btn btn-link" id="cancelImageChanges"><i class="fa fa-remove"></i> Discard</button>
+        <button class="btn btn-link margin-top-0" id="cancelImageChanges"><i class="fa fa-remove"></i> Discard</button>
       </p>
     </div>
 
@@ -73,7 +73,7 @@
 
       <p>
         <button class="btn btn-primary" id="applyCrop"><i class="fa fa-check"></i> Crop</button>
-        <button class="btn btn-link" id="cancelCrop"><i class="fa fa-remove"></i> Cancel</button>
+        <button class="btn btn-link margin-top-0" id="cancelCrop"><i class="fa fa-remove"></i> Cancel</button>
       </p>
     </div>
 
@@ -112,7 +112,7 @@
           <div class="col-xs-12">
             <p>
               <button class="btn btn-primary" id="applyResize"><i class="fa fa-check"></i> Resize</button>
-              <button class="btn btn-link" id="cancelResize"><i class="fa fa-remove"></i> Cancel</button>
+              <button class="btn btn-link margin-top-0" id="cancelResize"><i class="fa fa-remove"></i> Cancel</button>
             </p>
           </div>
         </div>
@@ -137,7 +137,7 @@
           <div class="col-xs-12">
             <p>
               <button class="btn btn-primary" id="applyRotate"><i class="fa fa-check"></i> Apply rotation</button>
-              <button class="btn btn-link" id="cancelRotate"><i class="fa fa-remove"></i> Cancel</button>
+              <button class="btn btn-link margin-top-0" id="cancelRotate"><i class="fa fa-remove"></i> Cancel</button>
             </p>
           </div>
         </div>


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4906#event-2601034513
## Description
Added css rules for cancel buttons to centering them.
## Screenshots/screencasts
https://cl.ly/8e02c621fa91
## Backward compatibility
This change is fully backward compatible.