### PR TITLE
Stop dragging when the cursor leaves crop frame 

### DIFF
--- a/js/canvasEditor.js
+++ b/js/canvasEditor.js
@@ -163,10 +163,10 @@ CanvasEditor.prototype.notInBorders = function(coords, mousePos) {
   var mouseX = mousePos.pageX - $container.offset().left;
   var mouseY = mousePos.pageY - $container.offset().top;
 
-  return ((coords.x === 0 && mouseX < 0) || 
-       (coords.y === 0 &&  mouseY < 0) || 
-       (coords.x2 === containerSize.width && mouseX > containerSize.width) || 
-       (mouseY > containerSize.height && coords.y2 === containerSize.height))
+  return (coords.x === 0 && mouseX < 0)
+    ||  (coords.y === 0 &&  mouseY < 0)
+    ||  (coords.x2 === containerSize.width && mouseX > containerSize.width)
+    ||  (mouseY > containerSize.height && coords.y2 === containerSize.height);
 }
 
 CanvasEditor.prototype.createCropMask = function(updateCropCoords) {

--- a/js/canvasEditor.js
+++ b/js/canvasEditor.js
@@ -154,6 +154,21 @@ CanvasEditor.prototype.cropEditorCanvas = function(x, y, w, h, callback) {
   this.cropCanvas(this.editorCanvas, x, y, w, h, callback);
 };
 
+CanvasEditor.prototype.notInBorders = function(coords, mousePos) {
+  var $container = $(this.editorCanvas).parent();
+  var containerSize = {
+    height: $container.innerHeight(),
+    width: $container.innerWidth()
+  };
+  var mouseX = mousePos.pageX - $container.offset().left;
+  var mouseY = mousePos.pageY - $container.offset().top;
+
+  return ((coords.x === 0 && mouseX < 0) || 
+       (coords.y === 0 &&  mouseY < 0) || 
+       (coords.x2 === containerSize.width && mouseX > containerSize.width) || 
+       (mouseY > containerSize.height && coords.y2 === containerSize.height))
+}
+
 CanvasEditor.prototype.createCropMask = function(updateCropCoords) {
   var that = this;
 
@@ -173,6 +188,10 @@ CanvasEditor.prototype.createCropMask = function(updateCropCoords) {
         if (!that.isCoordsEquel(coords, that.lastCropCoordindates)) {
           updateCropCoords(coords, proportion);
           lastCropCoordindates = coords;
+        }
+
+        if (that.notInBorders(coords, event)) {
+          $(event.target).trigger('mouseup');
         }
       },
       onRelease: function () {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/1009

## Description
Stop dragging when the cursor leaves crop frame 

## Screenshots/screencasts
![issue-1009](https://user-images.githubusercontent.com/53430352/64945528-634ace00-d879-11e9-91a5-91f2925029f1.gif)


## Backward compatibility

This change is fully backward compatible.

## Notes
Added new function witch tracking the cursor position, and call 'mouse up' event to stop dragging when it leaves the frame.