### PR TITLE
Edge and IE will have normal behavior when we crop or resize an image.

### DIFF
--- a/js/canvasEditor.js
+++ b/js/canvasEditor.js
@@ -143,7 +143,7 @@ CanvasEditor.prototype.cropCanvas = function (canvas, x, y, w, h, callback) {
     var context = canvas.getContext('2d');
     canvas.width = w;
     canvas.height = h;
-    context.drawImage(image, x, y, w, h, 0, 0, w, h);
+    context.drawImage(image, x, y, w, h);
     callback();
     that.afterRenderCallback();
   });

--- a/js/interface.js
+++ b/js/interface.js
@@ -163,7 +163,9 @@ function saveChanges() {
           Fliplet.Widget.complete();
         } else {
           hideSaveButtons();
-          hideLoader();
+          setTimeout(function(){
+            hideLoader();            
+          }, 0);
         }
       });
     })


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/1214
https://github.com/Fliplet/fliplet-studio/issues/3116
https://github.com/Fliplet/fliplet-studio/issues/3684

## Description
Edge and IE will have normal behavior when we crop or resize an image.

## Screenshots/screencasts
![issues-1214-3116-3684](https://user-images.githubusercontent.com/53430352/65438160-b13d7400-de2d-11e9-9849-c0c90fcae4c9.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
The issue occurred because of the  `toBlob` method. IE has a similar function called `msToBlob` but it is not working correctly enough to use it. Therefore to avoid this issue we need to add `toBlob` polyfill for Edge and IE. I'd recommend using [this polyfill](https://stackoverflow.com/questions/47475647/canvas-to-blob-on-edge/47487073#47487073?newreg=5c1e574961bd4627a8c1dc6d3be24dea) because it worked just great to solve this issue when I added it to the `interface.js` file.
