### PR TITLE
White fields will not appear after image crop 

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -146,7 +146,7 @@ function saveChanges() {
     : 'png';
   var mimeType = EXTENSION_MIME_MAP[extension];
 
-  canvasEditor.sourceCanvas.toBlob(function(result) {
+  canvasEditor.trimCanvas(canvasEditor.sourceCanvas).toBlob(function(result) {
     var formData = new FormData();
     var fileName = data.image.name.replace(/\.[^/.]+$/, "");
     formData.append("blob", result, fileName + '.' + extension);


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5027

## Description
White fields will not appear after image crop 

## Screenshots/screencasts
![issue-5027](https://user-images.githubusercontent.com/53430352/68214004-457e2780-ffe5-11e9-8f8b-dac9aa90f730.gif)


## Backward compatibility

This change is fully backward compatible.

## Notes
To test this PR on the Firefox browser we need to merge [this ](https://github.com/Fliplet/fliplet-widget-image-editor/pull/18) PR first.