### PR TITLE
Allow a user to resize an image

### DIFF
--- a/js/canvasEditor.js
+++ b/js/canvasEditor.js
@@ -8,6 +8,7 @@ var CanvasEditor = function(config){
   this.lastCropCoordindates;
   this.MAX_CANVAS_HEIGHT = 250;
   this.CROP_MASK_IDENTATION = 15;
+  this.currentMode = 'main';
   this.beforeRenderCallback = config.beforeRenderCallback || function(){};
   this.afterRenderCallback = config.afterRenderCallback || function(){};
 };
@@ -89,11 +90,15 @@ CanvasEditor.prototype.applyEditorCanvasChanges = function() {
 
 CanvasEditor.prototype.resizeCanvas = function(canvas, width, height, callback) {
   var that = this;
+  var canvasObject = this.currentMode === 'crop' ? this.trimCanvas(canvas) : canvas;
+
   callback = callback || function(){};
+
   if (width < 1) width = 1;
   if (height < 1) height = 1;
+  
   this.beforeRenderCallback();
-  this.HERMITE.resample(this.trimCanvas(canvas), width, height, true, function() {
+  this.HERMITE.resample(canvasObject, width, height, true, function() {
     that.afterRenderCallback();
     callback()
   });

--- a/js/interface.js
+++ b/js/interface.js
@@ -421,15 +421,19 @@ function switchEditorMode(mode) {
   switch (mode) {
     case EDITOR_MODE.CROP:
       selector = SELECTOR.IMAGE_EDITOR_CROP;
+      canvasEditor.currentMode = 'crop'
       break;
     case EDITOR_MODE.RESIZE:
       selector = SELECTOR.IMAGE_EDITOR_RESIZE;
+      canvasEditor.currentMode = 'resize'
       break;
     case EDITOR_MODE.ROTATE:
       selector = SELECTOR.IMAGE_EDITOR_ROTATE;
+      canvasEditor.currentMode = 'rotate'
       break;
     default:
       selector = SELECTOR.IMAGE_EDITOR_MAIN;
+      canvasEditor.currentMode = 'main'
   }
 
   $(selector).show();


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5310

## Description
Allow a user to resize an image

## Screenshots/screencasts
![issue-5310](https://user-images.githubusercontent.com/53430352/69159632-e940fa80-0af0-11ea-876b-32e3d63593ba.gif)


## Backward compatibility

This change is fully backward compatible.