### PR TITLE
Prevent click on save button while data is saving

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -139,6 +139,7 @@ function hideLoader() {
 }
 
 function saveChanges() {
+  Fliplet.Widget.toggleSaveButton(false);
   showLoader();
   var imageExt = data.image.hasOwnProperty('ext') ? data.image.ext.toLowerCase() : '';
   var extension = EXTENSION_MIME_MAP.hasOwnProperty(imageExt)
@@ -162,6 +163,7 @@ function saveChanges() {
         if (Fliplet.Env.get('providerMode') === 'fixed') {
           Fliplet.Widget.complete();
         } else {
+          Fliplet.Widget.toggleSaveButton(true);
           hideSaveButtons();
           setTimeout(function(){
             hideLoader();            


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5360

## Description
Prevent click on save button while data is saving

## Screenshots/screencasts
![click-while-save](https://user-images.githubusercontent.com/53430352/70623035-d7510400-1c25-11ea-90b8-6348d6e81bf2.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
This solution work in pair with this [PR](https://github.com/Fliplet/fliplet-widget-image/pull/48).