### PR TITLE
Altered the onerror function to get more information for the occurent error

### DIFF
--- a/js/canvasEditor.js
+++ b/js/canvasEditor.js
@@ -1,3 +1,14 @@
+window.onerror = function (msg, url, lineNo, columnNo, error) {
+  if (typeof Raven !== 'undefined') {
+    Raven.captureMessage('Error loading image:  ' + msg + '. At line: ' + lineNo + '. In the file: ' + url, {
+      user: Fliplet.User.get('id'),
+      mediaFile: _this.originalImage,
+      errorObject: error
+    });
+  }
+  return false;
+}
+
 var CanvasEditor = function(config){
   this.sourceCanvas = config.sourceCanvas;
   this.editorCanvas = config.editorCanvas;
@@ -37,12 +48,6 @@ CanvasEditor.prototype.loadImageFromUrl = function(imgUrl, callback) {
   img.onload = function() {
     callback(null, img);
   };
-
-  img.onerror = function() {
-    if (typeof Raven !== 'undefined') {
-      Raven.captureMessage('Error loading image', { user: Fliplet.User.get('id'), mediaFile: _this.originalImage });
-    }
-  }
 
   img.src = src;
 


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5228

## Description
Altered the `on error` function to get more information for the occurrent error

## Backward compatibility

This change is fully backward compatible.

## Notes
This is needed so we could log more information about the current error and find out why it happens.