### PR TITLE
Fixed wide image display on the IE 11

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -151,7 +151,7 @@ html.provider-inline .image-widget-holder {
 .editCanvasWrapper canvas {
   margin: auto;
   max-height: 250px !important;
-  max-width: 100%;
+  max-width: 94vw;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5392

## Description
Fixed wide image display on the IE 11

## Screenshots/screencasts
![wide-image-ie](https://user-images.githubusercontent.com/53430352/71359750-4cadc480-2596-11ea-8a9d-0546fe967364.gif)


## Backward compatibility

This change is fully backward compatible.

## Notes
Works together with this [PR](https://github.com/Fliplet/fliplet-widget-image/pull/51).