### PR TITLE
Showing full-wide image to a user when he tries to change it in the image-editor

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -45,6 +45,14 @@ html.provider-inline .image-widget-holder {
   background-color: transparent;
   padding: 10px;
   min-height: 230px;
+
+}
+
+/* Fix IE 11 vertical align according to the known issue https://github.com/philipwalton/flexbugs/issues/231 */
+#preview-image-editor:after{
+  content:'';
+  min-height:inherit;
+  font-size:0;
 }
 
 #preview-image-editor img {
@@ -146,6 +154,7 @@ html.provider-inline .image-widget-holder {
 .editCanvasWrapper {
   display: inline-block;
   font-size: 0;
+  width: 100%;
 }
 
 .editCanvasWrapper canvas {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5392

## Description
Showing full-wide image to a user when he tries to change it in the image-editor

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/74531366-1c9af600-4f35-11ea-90c6-76f0bd442047.png)


## Backward compatibility

This change is fully backward compatible.